### PR TITLE
fix: use lowercase for workflow in parameters

### DIFF
--- a/content/boomerang-flow/3.4.0/getting-to-know/06.parameters.md
+++ b/content/boomerang-flow/3.4.0/getting-to-know/06.parameters.md
@@ -28,7 +28,7 @@ The substitution is performed by the Workflow service when a Workflow is execute
 | --------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------ |
 | Global          | Throughout the Workflow lifecycle. These are defined in Boomerang Flow by Administrators.                                | `$(global.params.<parameter>)`            | `$(global.params.slackChannel)`                  |
 | Team            | Throughout the Workflow lifecycle. These are defined in Boomerang Flow by teams.                                         | `$(team.params.<parameter>)`              | `$(team.params.slackChannel)`                    |
-| Workflow        | Throughout the Workflow lifecycle. Created and set by a user through Editor inputs.                                      | `$(Workflow.params.<parameter>)`          | `$(Workflow.params.slackChannel)`                |
+| Workflow        | Throughout the Workflow lifecycle. Created and set by a user through Editor inputs.                                      | `$(workflow.params.<parameter>)`          | `$(workflow.params.slackChannel)`                |
 | System          | Specific reserved parameters available at the execution of a Workflow.                                                   | `$(system.params.<parameter>)`            | `$(system.params.Workflow-activity-id)`          |
 | Params          | The flattened parameters with all inheritance and substitution resolved.                                                 | `$(params.<parameter>)`                   | `$(params.slackChannel)`                         |
 | Task Results    | At completion of a Task execution, these parameters can be referenced by other Tasks during the same Workflow execution. | `$(Task.<Task name>.results.<parameter>)` | `$(Task.My Wait For Event.results.eventPayload)` |
@@ -90,7 +90,7 @@ Boomerang Flow parameters are very similar to what you will find in Tekton<sup>Â
 | -      | -       | Global         | `$(global.params.<parameter>)` or `$(params.<parameter>)`   |
 | -      | -       | Team           | `$(global.params.<parameter>)` or `$(params.<parameter>)`   |
 | -      | -       | Pipeline       | `$(params.<param name>)`                                    |
-| -      | -       | Workflow       | `$(Workflow.params.<parameter>)` or `$(params.<parameter>)` |
+| -      | -       | Workflow       | `$(workflow.params.<parameter>)` or `$(params.<parameter>)` |
 | -      | -       | Context        | `$(context.pipeline.name)`                                  | System | `$(system.params.Workflow-name)` or `$(params.<parameter>)` |
 | -      | -       | Task           | `$(params.<param name>)`                                    | Task | `$(params.<param name>)` |
 

--- a/content/boomerang-flow/3.4.0/tutorials/03.github-teams.md
+++ b/content/boomerang-flow/3.4.0/tutorials/03.github-teams.md
@@ -45,7 +45,7 @@ For the **Invite User to Organization** Task, enter the following specifics.
 
 - Task Name: The name of this Task `Invite User to Organization`
 - URL, Token and Organization Name: can be filled in as in the previous Tasks
-- User Email Address: Reference to the flow parameter holding the email address of the member that will get invited to the organization `$(Workflow.params.emailAddress)`
+- User Email Address: Reference to the flow parameter holding the email address of the member that will get invited to the organization `$(workflow.params.emailAddress)`
 
 For the **Invite Member to Team** Task, enter the following specifics.
 

--- a/content/boomerang-flow/3.4.1/getting-to-know/06.parameters.md
+++ b/content/boomerang-flow/3.4.1/getting-to-know/06.parameters.md
@@ -28,7 +28,7 @@ The substitution is performed by the Workflow service when a Workflow is execute
 | --------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------- | ------------------------------------------------ |
 | Global          | Throughout the Workflow lifecycle. These are defined in Boomerang Flow by Administrators.                                | `$(global.params.<parameter>)`            | `$(global.params.slackChannel)`                  |
 | Team            | Throughout the Workflow lifecycle. These are defined in Boomerang Flow by teams.                                         | `$(team.params.<parameter>)`              | `$(team.params.slackChannel)`                    |
-| Workflow        | Throughout the Workflow lifecycle. Created and set by a user through Editor inputs.                                      | `$(Workflow.params.<parameter>)`          | `$(Workflow.params.slackChannel)`                |
+| Workflow        | Throughout the Workflow lifecycle. Created and set by a user through Editor inputs.                                      | `$(workflow.params.<parameter>)`          | `$(workflow.params.slackChannel)`                |
 | System          | Specific reserved parameters available at the execution of a Workflow.                                                   | `$(system.params.<parameter>)`            | `$(system.params.Workflow-activity-id)`          |
 | Params          | The flattened parameters with all inheritance and substitution resolved.                                                 | `$(params.<parameter>)`                   | `$(params.slackChannel)`                         |
 | Task Results    | At completion of a Task execution, these parameters can be referenced by other Tasks during the same Workflow execution. | `$(Task.<Task name>.results.<parameter>)` | `$(Task.My Wait For Event.results.eventPayload)` |
@@ -90,7 +90,7 @@ Boomerang Flow parameters are very similar to what you will find in Tekton<sup>Â
 | -      | -       | Global         | `$(global.params.<parameter>)` or `$(params.<parameter>)`   |
 | -      | -       | Team           | `$(global.params.<parameter>)` or `$(params.<parameter>)`   |
 | -      | -       | Pipeline       | `$(params.<param name>)`                                    |
-| -      | -       | Workflow       | `$(Workflow.params.<parameter>)` or `$(params.<parameter>)` |
+| -      | -       | Workflow       | `$(workflow.params.<parameter>)` or `$(params.<parameter>)` |
 | -      | -       | Context        | `$(context.pipeline.name)`                                  | System | `$(system.params.Workflow-name)` or `$(params.<parameter>)` |
 | -      | -       | Task           | `$(params.<param name>)`                                    | Task | `$(params.<param name>)` |
 

--- a/content/boomerang-flow/3.4.1/tutorials/03.github-teams.md
+++ b/content/boomerang-flow/3.4.1/tutorials/03.github-teams.md
@@ -45,7 +45,7 @@ For the **Invite User to Organization** Task, enter the following specifics.
 
 - Task Name: The name of this Task `Invite User to Organization`
 - URL, Token and Organization Name: can be filled in as in the previous Tasks
-- User Email Address: Reference to the flow parameter holding the email address of the member that will get invited to the organization `$(Workflow.params.emailAddress)`
+- User Email Address: Reference to the flow parameter holding the email address of the member that will get invited to the organization `$(workflow.params.emailAddress)`
 
 For the **Invite Member to Team** Task, enter the following specifics.
 


### PR DESCRIPTION
`workflow` should be lowercase in parameters

#### Changelog

**Changed**

- fix the letter case for workflow

#### Testing / Reviewing

1. Add a workflow parameter, for example `foo`
2. Create a `Execute Shell` task with `echo $(Workflow.params.foo)` as content
3. Execute the flow.
4. `Workflow.params.foo: command not found` will occur.
