### PR TITLE
Update eventing architecture docs for `lib.eventing`

### DIFF
--- a/content/boomerang-flow/3.5.0/architecture/05.eventing.md
+++ b/content/boomerang-flow/3.5.0/architecture/05.eventing.md
@@ -188,3 +188,11 @@ The entire CloudEvent data attribute becomes a Workflow input parameter called `
 **Wait For Event Result Payload Parameter**
 
 The entire CloudEvent data attribute becomes a Task result parameter called `eventPayload` that you can access in other Tasks following the result parameter reference.
+
+## Boomerang Eventing Library
+
+To facilitate eventing through NATS, all eventing-related services have Boomerang Eventing Library ([`lib.eventing`](https://github.com/boomerang-io/lib.eventing)) integrated - a Maven plugin that supports event streaming through NATS Jetstream.
+
+This plugin has been built on top of [`jnats`](https://github.com/nats-io/nats.java) client library, targeting an easier integration with NATS Jetstream for Boomerang Flow, as well as for external applications that want to publish and subscribe to Flow-related events from Boomerang.
+
+See the GitHub repo for [Boomerang Eventing Library](https://github.com/boomerang-io/lib.eventing) for more details and documentation.


### PR DESCRIPTION
Closes boomerang-io/roadmap#300

#### Changelog

- Updated eventing documentation to include information about `lib.eventing`.